### PR TITLE
Center stars in the 'lu' element, not force them to be align on left

### DIFF
--- a/src/angular-rating-icons.css
+++ b/src/angular-rating-icons.css
@@ -1,5 +1,4 @@
 .angular-rating-icons {
-    text-align: left;
     display: inline-block;
     padding: 0;
     list-style: none;

--- a/src/angular-rating-icons.js
+++ b/src/angular-rating-icons.js
@@ -107,7 +107,7 @@ angular.module('angular-rating-icons', [])
                     css.width = (scope.size - 2) / 2 + 'px';
 
                     if (!(index % 2)) {
-                        css['padding-right'] = '0';
+                        css['padding-right'] = scope.spacing / 2 + 'px';
                     }
 
                     return css;


### PR DESCRIPTION
"text-align: left;" property has forcing the stars align left when the 'lu' element was bigger them the with of all stars. 